### PR TITLE
Laravel 6.0 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "illuminate/support": "5.3.x|5.6.x"
+        "illuminate/support": "5.3.x|5.6.x|^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This closes #1 

From what I could tell based on `composer.json`, this package is compatible up to Laravel 5.6. I went through the [respective](https://laravel.com/docs/5.7/upgrade) [upgrade](https://laravel.com/docs/5.8/upgrade) [guides](https://laravel.com/docs/6.x/upgrade) and did not find any further changes necessary.

Since Laravel, starting from `6.0`, follows Semantic Versioning, the new constraint can safely be `^6.0`. Backwards compatibility is not affected.

Let me know if you would like me to make any changes to this PR!